### PR TITLE
壁衝突時のバグを修正

### DIFF
--- a/step4/nc_breakout.cpp
+++ b/step4/nc_breakout.cpp
@@ -45,15 +45,15 @@ move_ball(void) {
   by += vy;
   if (bx < 0) {
     bx = 0;
-    vx = abs(vx);
+    vx = -vx;
   }
   if (by < 0) {
     by = 0;
-    vy = abs(vy);
+    vy = -vy;
   }
   if (bx > 80) {
     bx = 80;
-    vx = -abs(vx);
+    vx = -vx;
   }
   if (by > 24) {
     by = 24;

--- a/step5/nc_breakout.cpp
+++ b/step5/nc_breakout.cpp
@@ -76,15 +76,15 @@ move_ball(void) {
   by += vy;
   if (bx < 0) {
     bx = 0;
-    vx = abs(vx);
+    vx = -vx;
   }
   if (by < 0) {
     by = 0;
-    vy = abs(vy);
+    vy = -vy;
   }
   if (bx > 80) {
     bx = 80;
-    vx = -abs(vx);
+    vx = -vx;
   }
   if (by > 24) {
     by = 24;


### PR DESCRIPTION
壁衝突時にボールがうまく反射しませんでした。
壁衝突時に進行方向の逆を進めばよいと思ったので、絶対値を取るようなプログラムから符号を反転するようなプログラムに修正しました。